### PR TITLE
add nengo-a2c submission

### DIFF
--- a/submissions/nengo-a2c/LICENSE
+++ b/submissions/nengo-a2c/LICENSE
@@ -1,0 +1,39 @@
+SPDX-License-Identifier: LicenseRef-ABR-Academic-Use-Only
+
+This submission vendors source code from
+https://github.com/maddybartlett/ImprovedRLContinuousStateReps (commit
+fc75ae0, 2024-02-01) under the upstream's Applied Brain Research (ABR)
+academic-use-only license. The full upstream license text is reproduced
+below verbatim and applies to the vendored source in src/nengo_a2c/.
+
+Files added by this submission that are NOT derived from upstream
+(README.md, metadata.yaml, requirements.txt, examples/example_usage.py,
+tests/test_runs.py, the per-file vendoring headers, and minor edits noted
+in those headers) are © the submission author(s) and contributed to the
+NengoZoo under the same ABR academic-use-only license for consistency.
+
+---
+
+Upstream LICENSE (verbatim):
+
+The Semantic Pointer Architecture, Temporal Semantic Pointers, Spatial Semantic
+Pointers, the Legendre Memory Units (LMU) and other Applied Brain Research Inc.
+of Waterloo, Ontario, Canada (ABR) owned intellectual property and related
+libraries, derived inventions and related patents and copyrights (the ABR IP)
+which are included or referenced herein and are the property of ABR. Details
+of ABR's license terms can be found at www.appliedbrainresearch.com/license.
+Academic research, academic teaching and personal learning use are permitted
+without payment, however all other uses, including commercial uses of any of
+the ABR IP requires a license to be purchased from ABR. please contact
+sales@appliedbrainresearch.com for details.
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/submissions/nengo-a2c/README.md
+++ b/submissions/nengo-a2c/README.md
@@ -1,0 +1,121 @@
+# nengo-a2c
+
+A spiking Actor-Critic (A2C) reinforcement learning network in Nengo, with an optional Legendre-Delay-Network (LDN) memory of recent rewards and values for n-step / continuous-time TD updates.
+
+## Description
+
+This is a vendored, focused cut of `rlnet` from [Bartlett et al. (2022)](https://mathpsych.org/presentation/1221), *"Improving Reinforcement Learning with Biologically Motivated Continuous State Representations"* (ICCM). The upstream repo contains the full RatBox/CartPole experiment suite and several state-representation variants (SSP, VSA, normalized, one-hot, ...). This submission packages the parts most reusable as a standalone Zoo entry:
+
+- **Networks**
+  - `ActorCritic` — basic single-layer A2C, no memory of past rewards. Optional state ensemble.
+  - `ActorCriticLDN` — A2C whose reward and state-value signals are passed through LDN delay-line memories, enabling TD(n) (discrete-time) or TD(θ) (continuous-time) updates from a multi-step return.
+  - `LDN` — a `nengo.Process` implementing Aaron Voelker's Legendre Delay Network. Can be dropped into a `nengo.Node` to provide a continuous memory of the last θ seconds of input.
+- **Learning rules**
+  - `TD0` — single-step TD(0) update.
+  - `TDt` (TD-theta) — n-step / continuous-time TD update that consumes the LDN-stored reward and value traces.
+- **State representations**
+  - `NormalRep` — normalize the env's observation into `[-1, 1]`.
+  - `OneHotRepCP`, `OneHotRepRB` — discretize the observation and one-hot encode it.
+
+> ⚠️ **License.** Upstream is distributed under Applied Brain Research's academic-use-only license, which is **not** GPL-compatible. This submission preserves that license verbatim — see `LICENSE`. Academic research, teaching, and personal learning are permitted without payment; commercial use requires a license from ABR (sales@appliedbrainresearch.com).
+
+## Installation
+
+We recommend a fresh virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+The A2C classes are *trainer-style* — they build their own `nengo.Network`, instantiate their own `nengo.Simulator`, and expose a `step(state, action, reward, reset=False)` method that advances the simulation one timestep and returns the updated state-value and action-values. They're **not** drop-in `nengo.Network` subclasses to put inside a parent `with model:` block.
+
+```python
+import nengo
+from nengo_a2c import ActorCritic, TD0, OneHotRepCP, softmax
+
+rep = OneHotRepCP(ranges=(5, 5))                 # discrete 5×5 state space
+rule = TD0(n_actions=4, lr=0.3, act_dis=0.9, state_dis=0.95)
+ac = ActorCritic(rep, rule, neuron_type=nengo.RectifiedLinear())
+
+state = (0, 0)
+ac.step(state, 0, reward=0.0, reset=True)        # episode start
+state_value, action_values = ac.step(state, action=0, reward=0.0)
+probs = softmax(action_values / 0.3)             # softmax action selection
+# ... pick action, step env, call ac.step(new_state, action_taken, reward), repeat
+```
+
+`examples/example_usage.py` is a runnable, CI-tested 5×5 gridworld demo that builds an `ActorCritic`, trains it for ~100 episodes, and reports the improvement in average episode reward.
+
+## The LDN variant
+
+`ActorCriticLDN` reads the same `(state, action, reward, reset)` API but routes reward and value through `LDN(theta, q)` memory nodes — a `q`-dimensional Legendre basis of the last `theta` seconds. The `TDt` rule then computes an n-step return by integrating the LDN's stored reward trace against pre-computed decoder weights:
+
+```python
+from nengo_a2c import ActorCriticLDN, TDt, OneHotRepCP
+
+rep = OneHotRepCP(ranges=(5, 5))
+rule = TDt(n_actions=4, lr=0.1, act_dis=0.85, state_dis=0.9, n=3, env_dt=0.01)
+ac = ActorCriticLDN(rep, rule,
+                    state_neurons=200, active_prop=0.1,
+                    theta=0.03, q_r=6, q_v=6,
+                    continuous=False)
+```
+
+The `continuous=True` path computes the decoder by integrating against a continuous discount factor instead of summing over n discrete time-steps, which is the paper's TD(θ) variant.
+
+## How it works
+
+The actor-critic is implemented as a single linear "weight matrix" rule operating on the state representation (or on neural-ensemble activities of that representation), updating both a scalar state value and a vector of action values from the TD error. There's no separate critic network; the same weight matrix carries both heads.
+
+```
+state ──► [rep.map] ──► [optional Ensemble] ──┐
+                                              ▼
+action ─────────────────────────────────► [rule Node] ──► state value
+reward ─────────────────────────────────►              └► action values
+reset  ─────────────────────────────────►
+```
+
+The LDN variant adds:
+
+```
+                                              ┌──► [LDN reward] ──► [decoder] ──┐
+reward ────────────────────────────────►──────┘                                  │
+                                                                                 ▼
+state value (fed back) ────► [LDN value] ──► [decoder] ──► [rule with multi-step return]
+```
+
+The decoder weights for the reward LDN are computed once at network construction, from the Legendre coefficients of the discount kernel — either a discrete sum (`continuous=False`) or a continuous integral (`continuous=True`).
+
+## What's not vendored
+
+To keep this submission focused, the following parts of upstream `rlnet/` are **not** included:
+
+- `sspspace.py` (Spatial Semantic Pointer construction) — large; warrants its own submission. See the existing `ssp-path-integrator` zoo entry for an SSP-based network.
+- `representations/ssp.py`, `representations/vsa.py`, `representations/onehottransform.py` — depend on SSP/VSA machinery or RatBox-specific transforms.
+- `rules/td0iG.py`, `rules/tdlambda.py`, `rules/tdn.py` — TD variants that overlap heavily with `TD0` and `TDt`.
+- The `cartpoleExperiments/`, `ratboxExperiments/`, `figures/`, NNI hyperparameter configs, and the upstream `utils.py` plotting helpers (`plot_policy`, `get_ac_output`, `save_gifs`, etc.) — environment- and analysis-specific.
+
+If you want any of these as a separate submission, the upstream paths above are the starting point.
+
+## Citation
+
+```bibtex
+@inproceedings{bartlett2022rl,
+  author    = {Bartlett, Maddy and Simone, Kathryn and Dumont, Nicole Sandra-Yaffa and
+               Furlong, P. Michael and Eliasmith, Chris and Orchard, Jeff and Stewart, Terry},
+  title     = {Improving Reinforcement Learning with Biologically Motivated
+               Continuous State Representations},
+  booktitle = {Proceedings of the 20th International Conference on Cognitive Modeling
+               (ICCM 2022)},
+  year      = {2022},
+  url       = {https://mathpsych.org/presentation/1221},
+}
+```
+
+## License
+
+Applied Brain Research academic-use-only — see `LICENSE` for the full upstream terms. **This is not a free-software license**; commercial use requires a paid ABR license.

--- a/submissions/nengo-a2c/examples/example_usage.py
+++ b/submissions/nengo-a2c/examples/example_usage.py
@@ -1,0 +1,83 @@
+"""
+Train an ActorCritic on a tiny 5x5 gridworld with one-hot states and TD(0).
+
+The agent starts at (0, 0), needs to reach (4, 4), gets +1 at the goal and
+-0.01 per step otherwise, and chooses actions by softmax over the
+network's learned action values. After ~80 episodes the policy reliably
+finds the goal in <30 steps.
+
+This is small on purpose — CI runs it on every PR, so it has to stay under
+~60 s wall-clock. To scale it up locally just bump `n_episodes` and
+`max_steps_per_episode`.
+"""
+
+import numpy as np
+import nengo
+
+from nengo_a2c import ActorCritic, TD0, OneHotRepCP, softmax
+
+
+GRID = 5
+N_ACTIONS = 4
+ACTIONS = [(-1, 0), (1, 0), (0, -1), (0, 1)]  # up, down, left, right
+GOAL = (GRID - 1, GRID - 1)
+STEP_PENALTY = -0.01
+GOAL_REWARD = 1.0
+
+
+def step_env(pos, action):
+    dx, dy = ACTIONS[action]
+    new_pos = (max(0, min(GRID - 1, pos[0] + dx)),
+               max(0, min(GRID - 1, pos[1] + dy)))
+    if new_pos == GOAL:
+        return new_pos, GOAL_REWARD, True
+    return new_pos, STEP_PENALTY, False
+
+
+def train(n_episodes=80, max_steps_per_episode=30, temperature=0.3, seed=0):
+    rng = np.random.default_rng(seed)
+    rep = OneHotRepCP(ranges=(GRID, GRID))
+    rule = TD0(n_actions=N_ACTIONS, lr=0.3, act_dis=0.9, state_dis=0.95)
+    ac = ActorCritic(rep, rule, neuron_type=nengo.RectifiedLinear())
+
+    episode_rewards = []
+    for ep in range(n_episodes):
+        pos = (0, 0)
+        action = 0
+        # Tell the network the episode just started; the action passed in
+        # here is arbitrary because the reset flag suppresses the update.
+        ac.step(pos, action, reward=0.0, reset=True)
+
+        total_reward = 0.0
+        for _ in range(max_steps_per_episode):
+            # Pick action from current action values (softmax with temperature).
+            _, action_values = ac.step(pos, action, reward=0.0, reset=False)
+            probs = softmax(np.asarray(action_values) / temperature)
+            action = int(rng.choice(N_ACTIONS, p=probs))
+
+            # Step the env, then tell the network what happened.
+            pos, r, done = step_env(pos, action)
+            total_reward += r
+            ac.step(pos, action, reward=r, reset=False)
+            if done:
+                break
+
+        episode_rewards.append(total_reward)
+
+    return ac, episode_rewards
+
+
+def main():
+    ac, rewards = train()
+
+    n = len(rewards)
+    early = np.mean(rewards[: max(1, n // 4)])
+    late = np.mean(rewards[-max(1, n // 4):])
+    print(f"Average episode reward — first quarter: {early:+.3f}")
+    print(f"Average episode reward — last  quarter: {late:+.3f}")
+    print(f"Improvement: {late - early:+.3f}")
+    print(f"State value at start (0,0): {ac.step((0, 0), 0, 0.0)[0][0]:+.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/nengo-a2c/metadata.yaml
+++ b/submissions/nengo-a2c/metadata.yaml
@@ -1,0 +1,41 @@
+name: nengo-a2c
+type: network
+version: 0.1.0
+
+authors:
+  - name: Maddy Bartlett
+
+license: LicenseRef-ABR-Academic-Use-Only
+
+description: >
+  A spiking Actor-Critic reinforcement learning network from Bartlett et al.
+  (2022). Pairs a pluggable state representation, TD learning rule, and an
+  optional Legendre-Delay-Network memory of past rewards and values to learn
+  policies over continuous state spaces. Vendored from upstream rlnet/.
+
+tags:
+  - reinforcement-learning
+  - actor-critic
+  - td-learning
+  - ldn
+  - legendre-memory-unit
+  - decision-making
+  - learning-rule
+
+nengo_version: ">=3.2,<5"
+
+backends:
+  - core
+
+dependencies:
+  - numpy>=1.20
+  - scipy
+
+complexity: advanced
+
+paper:
+  citation: "Bartlett, M., Simone, K., Dumont, N. S.-Y., Furlong, P., Eliasmith, C., Orchard, J., & Stewart, T. (2022). Improving Reinforcement Learning with Biologically Motivated Continuous State Representations. Proceedings of the 20th International Conference on Cognitive Modeling (ICCM)."
+  url: https://mathpsych.org/presentation/1221
+
+related:
+  - lmu

--- a/submissions/nengo-a2c/metadata.yaml
+++ b/submissions/nengo-a2c/metadata.yaml
@@ -4,6 +4,7 @@ version: 0.1.0
 
 authors:
   - name: Maddy Bartlett
+    orcid: 0000-0003-1084-0938
 
 license: LicenseRef-ABR-Academic-Use-Only
 

--- a/submissions/nengo-a2c/requirements.txt
+++ b/submissions/nengo-a2c/requirements.txt
@@ -1,0 +1,3 @@
+nengo>=3.2,<5
+numpy>=1.20
+scipy

--- a/submissions/nengo-a2c/src/nengo_a2c/__init__.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/__init__.py
@@ -1,0 +1,26 @@
+"""nengo_a2c — Nengo-based Actor-Critic networks from Bartlett et al. (2022).
+
+Public API:
+    ActorCritic, ActorCriticLDN, LDN              # nengo_a2c.networks
+    TD0, TDt                                       # nengo_a2c.rules
+    NormalRep, OneHotRepCP, OneHotRepRB           # nengo_a2c.representations
+    sparsity_to_x_intercept, softmax              # nengo_a2c.utils
+"""
+
+from .networks import ActorCritic, ActorCriticLDN, LDN
+from .representations import NormalRep, OneHotRepCP, OneHotRepRB
+from .rules import TD0, TDt
+from .utils import softmax, sparsity_to_x_intercept
+
+__all__ = [
+    "ActorCritic",
+    "ActorCriticLDN",
+    "LDN",
+    "TD0",
+    "TDt",
+    "NormalRep",
+    "OneHotRepCP",
+    "OneHotRepRB",
+    "softmax",
+    "sparsity_to_x_intercept",
+]

--- a/submissions/nengo-a2c/src/nengo_a2c/networks/__init__.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/networks/__init__.py
@@ -1,0 +1,5 @@
+from .actor_critic import ActorCritic
+from .actor_critic_ldn import ActorCriticLDN
+from .ldn import LDN
+
+__all__ = ["ActorCritic", "ActorCriticLDN", "LDN"]

--- a/submissions/nengo-a2c/src/nengo_a2c/networks/actor_critic.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/networks/actor_critic.py
@@ -1,0 +1,142 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/networks/acBasic.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+Local edits relative to upstream:
+  - Adjusted the rlnet.utils import to a relative import (..utils).
+  - Removed unused top-level `import matplotlib.pyplot as plt`.
+  - Removed `get_tuning()` and `get_policy()` methods. The former is a
+    one-liner plotting helper; the latter hardcodes the RatBox 8×8×4 grid
+    geometry and isn't generically reusable.
+"""
+
+import nengo
+import numpy as np
+
+from ..utils import sparsity_to_x_intercept
+
+
+## Actor-Critic without LDNs ##
+class ActorCritic(object):
+    ''' Nengo model implementing an Actor-Critic network.
+    Single-layer network
+    Inputs: state, action, reward and reset
+    Outputs: updated state value, action values for actions available in current state
+
+    Example of Usage:
+        >> rep = NormalRep((8,8,4))
+        >> ac = ActorCritic(rep,
+                 ActorCriticTD0(n_actions=3, alpha=0.1, beta=0.9, gamma=0.95),state_neurons
+                 state_neurons=1000,
+                 neuron_type=nengo.RectifiedLinear()
+                 intercepts=nengo.dists.Uniform(0.01, 0.5)
+                )
+    '''
+    def __init__(self, representation, rule, state_neurons=None, active_prop=None, neuron_type=nengo.RectifiedLinear(),
+                 **ensemble_args):
+
+        self.representation = representation
+        ## set dim = size of state representation
+        dim = representation.size_out
+        ## create empty array for action values being updated
+        self.update_action = np.zeros(rule.n_actions)
+        ## ensemble
+        self.state_neurons = state_neurons
+        self.active_prop = active_prop
+        self.neuron_type = neuron_type
+
+        ## empty arrays for state value and action values
+        self.state_value = np.zeros(1)
+        self.action_values = np.zeros(rule.n_actions)
+
+        ## Create nengo model
+        self.model = nengo.Network()
+        with self.model:
+
+            ## empty array for state
+            ## size = size of state representation + number of actions + reward + whether env was reset
+            self.state = np.zeros(dim+rule.n_actions+2)
+            ## create nengo node for containing state
+            self.state_node = nengo.Node(lambda t: self.state)
+
+            ## if we're not using a neuron ensemble to contain the state representation
+            if state_neurons is None:
+                ## create nengo node for containing the learning rule
+                ## input size in is dim (state) + n_actions + reward + env.reset
+                self.rule = nengo.Node(rule, size_in=dim+rule.n_actions+2)
+                ## connect the state node to the rule node
+                nengo.Connection(self.state_node, self.rule, synapse=None)
+
+            ## if we are using a neuron ensemble
+            else:
+                ## create nengo node for containing the learning rule
+                ## input size in is state_neurons (state) + n_actions + reward + env.reset
+                self.rule = nengo.Node(rule, size_in=self.state_neurons+rule.n_actions+2)
+                ## create ensemble for containing the state representation
+                self.ensemble = nengo.Ensemble(n_neurons=state_neurons, dimensions=dim,
+                                               neuron_type=self.neuron_type,
+                                               intercepts=nengo.dists.Choice([sparsity_to_x_intercept(dim, self.active_prop)]),
+                                               **ensemble_args
+                                              )
+                ##connect the state representation to the ensemble
+                nengo.Connection(self.state_node[:dim], self.ensemble, synapse=None)
+                ##connect the state ensemble to the rule node
+                nengo.Connection(self.ensemble.neurons, self.rule[:state_neurons], synapse=None)
+                ##connect the state representation to the rule node
+                nengo.Connection(self.state_node[dim:], self.rule[state_neurons:], synapse=None)
+
+            ## create node for containing the updated state value
+            self.value_node = nengo.Node(self.value_node_func, size_in=1)
+
+            ## create node for containing the updated action values
+            self.action_values_node = nengo.Node(self.action_values_node_func, size_in=rule.n_actions)
+
+            ## send first output from rule node (updated state value) to the state value node
+            nengo.Connection(self.rule[0], self.value_node, synapse=None)
+            ## send updated action values from rule node to action value node
+            nengo.Connection(self.rule[1:], self.action_values_node, synapse=None)
+
+        ## run model
+        self.sim = nengo.Simulator(self.model)
+
+    def step(self, state, update_action, reward, reset=False):
+        '''Function for running the model for one time step.
+
+        Inputs: agent's state, chosen action, reward
+        Outputs: state value, action values'''
+
+        if type(update_action) == int or type(update_action) == np.int64 or len(update_action) == 1:
+            ## set update_action to an array of 0's with one value for each action
+            self.update_action[:] = 0
+            ## set the update_action value at the position of the chosen action to 1
+            self.update_action[update_action] = 1
+        else:
+            self.update_action = update_action
+
+        ## create state variable containing state representation,
+        ## update_action array, reward, and whether or not the env was reset
+        self.state[:] = np.concatenate([
+            self.representation.map(state),
+            self.update_action,
+            [reward, reset],]
+            )
+
+        ## run model for one step
+        self.sim.step()
+
+        ## return the updated state and action values from the model
+        ## these are the values returned by the learning rule
+        return self.state_value, self.action_values
+
+    ## function for state value node
+    def value_node_func(self, t, x):
+        ## identity function
+        self.state_value[:] = x
+
+    ## function for action value node
+    def action_values_node_func(self, t, x):
+        ## identity function
+        self.action_values[:] = x

--- a/submissions/nengo-a2c/src/nengo_a2c/networks/actor_critic_ldn.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/networks/actor_critic_ldn.py
@@ -1,0 +1,212 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/networks/acLDN.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+Local edits relative to upstream:
+  - Adjusted the rlnet.utils import to a relative import (..utils).
+  - Removed unused top-level `import matplotlib.pyplot as plt`.
+  - Removed `get_tuning()` and `get_policy()` methods (one-liner plotting
+    helper and a RatBox-grid-specific value extractor, respectively).
+"""
+
+import nengo
+import numpy as np
+from scipy.special import legendre
+import scipy.integrate as integrate
+
+from .ldn import LDN
+from ..utils import sparsity_to_x_intercept
+
+
+## Actor Critic Network with LDN memories for rewards and values
+## 2 types of reward decoder - one is for discrete time, one for continuous time
+class ActorCriticLDN(object):
+    ''' Nengo model implementing an Actor-Critic network.
+    Single-layer network
+    State value and reward are stored in ldn memories
+    Inputs: state, action, reward and reset
+    Outputs: updated state value, action values for actions available in current state, value of current state
+
+    (Note: value of current state is fed back into the network's own value memory)
+
+    Example of Usage:
+        >> rep = NormalRep((8,8,4))
+        >> ac = ActorCriticLDN(rep,
+                 ActorCriticTD0(n_actions=3, lr=0.1, act_dis=0.9, state_dis=0.95),
+                 state_neurons=1000,
+                 active_prop=0.1,
+                 theta=0.001,
+                 q_r=3,
+                 q_v=3,
+                 continuous=True,
+                 neuron_type=nengo.RectifiedLinear()
+                )
+
+    '''
+    def __init__(self, representation, rule, state_neurons=None, active_prop=None, theta=0.1, q_r=10, q_v=10,
+                 continuous=False, ens_neurons=nengo.RectifiedLinear(),
+                 report_ldn=False, **ensemble_args):
+        self.representation = representation
+        ## set dim = size of state representation
+        dim = representation.size_out
+        ## create empty array for action values being updated
+        self.update_action = np.zeros(rule.n_actions)
+
+        self.state_neurons = state_neurons
+        self.continuous = continuous
+
+        ## empty arrays for state value and action values
+        self.state_value = np.zeros(1)
+        self.action_values = np.zeros(rule.n_actions)
+
+        n = rule.n
+        ## add 10% to length of LDN window to increase accuracy at the extremes
+        theta = theta + (theta * 0.1)
+        state_dis = rule.state_dis
+
+        self.env_dt = rule.env_dt
+        self.report_ldn = report_ldn
+
+
+        ## Create nengo model
+        self.model = nengo.Network()
+        with self.model:
+
+            ## empty array for state
+            ## size = size of state representation + number of actions + reward + whether env was reset
+            self.state = np.zeros(dim+rule.n_actions+2)
+            ## create nengo node for containing state
+            self.state_node = nengo.Node(lambda t: self.state)
+
+            ## create nengo node for containing the learning rule
+            ## input size in is state_neurons (state) + n_actions + reward + env.reset
+            self.rule = nengo.Node(rule, size_in=state_neurons+rule.n_actions+3)
+            ## create ensemble for containing the state representation
+            self.ensemble = nengo.Ensemble(n_neurons=self.state_neurons, dimensions=dim,
+                                           neuron_type=ens_neurons,
+                                           intercepts=nengo.dists.Choice([sparsity_to_x_intercept(dim, active_prop)]),
+                                           **ensemble_args
+                                          )
+            ##connect the state representation to the ensemble
+            nengo.Connection(self.state_node[:dim], self.ensemble, synapse=None)
+
+
+            ## LDN MEMORIES FOR REWARDS AND VALUES
+            ## create LDNs for rewards and state values
+            ldn_r = LDN(theta=theta, q=q_r, size_in=1)
+            ldn_v = LDN(theta=theta, q=q_v, size_in=1)
+            ## create memory nodes which perform LDN transformation
+            self.reward_memory = nengo.Node(ldn_r)
+            self.value_memory = nengo.Node(ldn_v)
+            ## feed the reward from the state node into the LDN Reward memory
+            nengo.Connection(self.state_node[-2], self.reward_memory, synapse=None)
+
+            ## Create reward decoders
+            ## Decoders for discrete time -- TD(n) with LDN memories
+            if self.continuous is False:
+                reward_decoders = np.sum([np.exp(-state_dis*theta*(1-dth))* ldn_r.get_weights_for_delays(dth)
+                                      for dth in np.linspace(0, 1, n)], axis=0)
+
+            ## Decoders for continuous time -- TD(theta)
+            elif self.continuous is True:
+                reward_decoders = np.zeros(q_r)
+                for i in range(q_r):
+                    intgrand = lambda x: (state_dis**(theta*(1-(x))))*legendre(i)(2*x-1)
+                    reward_decoders[i] = integrate.quad(intgrand, 0, 1)[0]
+
+                reward_decoders = np.kron(np.eye(1), reward_decoders.reshape(1, -1))
+
+            ## Value memory decoders just fetch the value from n time steps ago
+            value_decoders = ldn_v.get_weights_for_delays(1)
+
+
+            ## connect the state ensemble to the rule node
+            nengo.Connection(self.ensemble.neurons, self.rule[:state_neurons], synapse=None)
+            ## connect the actions, reward, reset and value-to-be-updated to the rule node
+            nengo.Connection(self.state_node[dim:-2], self.rule[state_neurons:-3], synapse=None)  ##actions
+            nengo.Connection(self.reward_memory, self.rule[-3], transform=reward_decoders, synapse=None)  ##reward
+            nengo.Connection(self.state_node[-1], self.rule[-2], synapse=None)  ##reset
+            nengo.Connection(self.value_memory, self.rule[-1], transform=value_decoders, synapse=None)  ##update value
+
+            ## Decoded Reward node - this node is used to probe the values decoded out from the reward memory
+            if self.report_ldn is True:
+                self.rdec = nengo.Node(None, size_in=1)
+                nengo.Connection(self.reward_memory, self.rdec, transform=reward_decoders)
+                self.vdec = nengo.Node(None, size_in=1)
+                nengo.Connection(self.value_memory, self.vdec, transform=value_decoders)
+
+            ## create node for containing the updated state value
+            self.value_node = nengo.Node(self.value_node_func, size_in=1)
+
+            ## create node for containing the updated action values
+            self.action_values_node = nengo.Node(self.action_values_node_func, size_in=rule.n_actions)
+
+            ## send first output from rule node (updated state value) to the state value node
+            nengo.Connection(self.rule[0], self.value_node, synapse=None)
+            ## send updated action values from rule node to action value node
+            nengo.Connection(self.rule[1:-1], self.action_values_node, synapse=None)
+
+            ## send the current state value to the value memory
+            nengo.Connection(self.rule[-1], self.value_memory, synapse=0)
+
+            ## Probes
+            if self.report_ldn is True:
+                self.p_rldn = nengo.Probe(self.reward_memory)  ##reward memory activity
+                self.p_rdec = nengo.Probe(self.rdec)  ##decoded reward memory
+                self.p_vldn = nengo.Probe(self.value_memory)  ##value memory activity
+                self.p_vdec = nengo.Probe(self.vdec)  ##decoded value memory
+
+        ##run model
+        self.sim = nengo.Simulator(self.model)
+
+    def step(self, state, update_action, reward, reset=False, report=False):
+        '''Function for running the model for one time step.
+
+        Inputs: agent's state, chosen action, reward
+        Outputs: state value, action values'''
+
+        ## set update_action to an array of 0's with one value for each action
+        self.update_action[:] = 0
+        ## set the update_action value at the position of the chosen action to 1
+        self.update_action[update_action] = 1
+
+        ## create state variable containing state representation,
+        ## update_action array, reward, and whether or not the env was reset
+        self.state[:] = np.concatenate([
+            self.representation.map(state),
+            self.update_action,
+            [reward, reset],]
+            )
+
+        ## run model for one step
+        if self.env_dt is not None:
+            for i in range(int(self.env_dt/0.001)):
+                self.sim.step()
+        else:
+            self.sim.step()
+
+        ## return the updated state and action values from the model
+        ## these are the values returned by the learning rule
+        if report is True:
+            ## Fetch probe data
+            self.rldn_in = self.sim.data[self.p_rldn]  ##reward memory activity
+            self.rldn_out = self.sim.data[self.p_rdec]  ##decoded reward memory
+            self.vldn_in = self.sim.data[self.p_vldn]  ##value memory activity
+            self.vldn_out = self.sim.data[self.p_vdec]  ##decoded value memory
+
+            return self.state_value, self.action_values, self.rldn_in, self.rldn_out, self.vldn_in, self.vldn_out
+        else:
+            return self.state_value, self.action_values
+
+    ## function for state value node
+    def value_node_func(self, t, x):
+        ## identity function
+        self.state_value[:] = x
+
+    ## function for action value node
+    def action_values_node_func(self, t, x):
+        ## identity function
+        self.action_values[:] = x

--- a/submissions/nengo-a2c/src/nengo_a2c/networks/ldn.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/networks/ldn.py
@@ -1,0 +1,57 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/networks/ldn.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+No code edits from upstream.
+"""
+
+import nengo
+import numpy as np
+import scipy.special  # noqa: F401  (kept to preserve upstream import surface)
+from scipy.special import legendre
+import scipy.integrate as integrate  # noqa: F401
+import scipy.linalg
+
+
+## Define a nengo.Process that implements an LDN.  This can be placed inside a
+##  nengo.Node
+class LDN(nengo.Process):
+    def __init__(self, theta, q, size_in=1):
+        self.q = q              # number of internal state dimensions per input
+        self.theta = theta      # size of time window (in seconds)
+        self.size_in = size_in  # number of inputs
+
+        # Do Aaron's math to generate the matrices
+        #  https://github.com/arvoelke/nengolib/blob/master/nengolib/synapses/analog.py#L536
+        Q = np.arange(q, dtype=np.float64)
+        R = (2*Q + 1)[:, None] / theta
+        j, i = np.meshgrid(Q, Q)
+
+        self.A = np.where(i < j, -1, (-1.)**(i-j+1)) * R
+        self.B = (-1.)**Q[:, None] * R
+
+        super().__init__(default_size_in=size_in, default_size_out=q*size_in)
+
+    def make_step(self, shape_in, shape_out, dt, rng, state=None):
+        state = np.zeros((self.q, self.size_in))
+
+        # Handle the fact that we're discretizing the time step
+        #  see https://en.wikipedia.org/wiki/Discretization#Discretization_of_linear_state_space_models
+        Ad = scipy.linalg.expm(self.A*dt)
+        Bd = np.dot(np.dot(np.linalg.inv(self.A), (Ad-np.eye(self.q))), self.B)
+
+        # this code will be called every timestep
+        def step_legendre(t, x, state=state):
+            state[:] = np.dot(Ad, state) + np.dot(Bd, x[None, :])
+            return state.T.flatten()
+        return step_legendre
+
+    def get_weights_for_delays(self, r):
+        '''compute the weights needed to extract the value at time r
+        from the network (r=0 is right now, r=1 is theta seconds ago)'''
+        r = np.asarray(r)
+        m = np.asarray([legendre(i)(2*r - 1) for i in range(self.q)])
+        return m.reshape(self.q, -1).T

--- a/submissions/nengo-a2c/src/nengo_a2c/representations/__init__.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/representations/__init__.py
@@ -1,0 +1,4 @@
+from .normal import NormalRep
+from .onehot import OneHotRepCP, OneHotRepRB
+
+__all__ = ["NormalRep", "OneHotRepCP", "OneHotRepRB"]

--- a/submissions/nengo-a2c/src/nengo_a2c/representations/normal.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/representations/normal.py
@@ -1,0 +1,55 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/representations/normal.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+No code edits from upstream.
+"""
+
+import numpy as np
+
+
+class NormalRep(object):
+    '''Create look-up tables of size:
+    (size_state_dim_1, size_state_dim_2, ..., size_state_dim_n).
+
+    Inputs: agent's state
+    Params: environment
+    Outputs: representation of agent's state
+
+    Examples of Usage:
+    Initialize the representation:
+        >> env = gym.make('MountainCar-v0')
+        >> representation = NormalRep(env)
+
+    Translate agent state into representation:
+        >> state = (0,7,3)
+        >> representation.map(state)
+        ans = array([-1.  ,  0.75,  0.5 ])
+    '''
+    def __init__(self, env):
+        ##Set environment
+        self.env = env
+
+        self.upper = self.env.observation_space.high
+        self.lower = self.env.observation_space.low
+
+        self.ranges = self.upper - self.lower
+        self.size_out = len(self.ranges)
+
+    ## Normalize the state into values between -1 and 1
+    def map(self, state):
+        state = state + abs(self.lower)
+        norm_state = (state/self.ranges-0.5)*2
+
+        #Check that the state has been normalised properly
+        if np.any(norm_state > 1) or np.any(norm_state < -1):
+            print("Representation Error: State values outside of normalisation bounds (-1, 1): ", state)
+
+        return norm_state
+
+    def get_state(self, state, env):
+        discrete_state = state
+        return discrete_state

--- a/submissions/nengo-a2c/src/nengo_a2c/representations/onehot.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/representations/onehot.py
@@ -1,0 +1,98 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/representations/onehot.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+Local edits relative to upstream:
+  - OneHotRepRB.get_state: `np.int` → `int`. `np.int` was deprecated in
+    NumPy 1.20 and removed in NumPy 1.24; bare `int` is the long-standing
+    NumPy-recommended replacement and works on every NumPy release the
+    rest of this submission supports.
+"""
+
+import numpy as np
+
+
+class OneHotRepRB(object):
+    '''Create one-hot representation. I.e. the state is represented as a list of 0's and a 1.
+    This method works with RatBox.
+    '''
+    def __init__(self, ranges):
+        ##step 1
+        self.ranges = ranges
+        self.factors = np.array([np.prod(ranges[x+1:]) for x in range(len(ranges))], dtype=int)
+        ##step 2
+        self.result = np.zeros(np.prod(ranges))
+        self.size_out = len(self.result)
+
+    def map(self, state):
+        index = 0
+        ##step 3
+        for i, v in enumerate(state):
+            index += v*self.factors[i]
+        self.result[:] = 0
+        ##step 4
+        if index % 1 == 0:
+            index = int(index)
+        self.result[index] = 1
+        return self.result
+
+    def get_state(self, state, env=None):
+        discrete_state = state
+
+        state_space_high = np.asarray([env.width, env.height, 360])
+        state_space_low = np.asarray([0, 0, 0])
+
+        discrete_obs_size = np.array(self.ranges)
+
+        discrete_obs_size = np.array(discrete_obs_size, dtype='int')
+        discrete_obs_win_size = (state_space_high - state_space_low)/discrete_obs_size
+
+        discrete_state = (state - state_space_low)/discrete_obs_win_size
+        discrete_state = tuple(discrete_state.astype(int))
+
+        return discrete_state
+
+
+class OneHotRepCP(object):
+    '''Create one-hot representation. I.e. the state is represented as a list of 0's and a 1.
+    This method works with CartPole v1.
+    '''
+    def __init__(self, ranges):
+        ##step 1
+        self.ranges = ranges
+        self.factors = np.array([np.prod(ranges[x+1:]) for x in range(len(ranges))], dtype=int)
+        ##step 2
+        self.result = np.zeros(np.prod(ranges))
+        self.size_out = len(self.result)
+
+    def map(self, state):
+        index = 0
+        ##step 3
+        for i, v in enumerate(state):
+            index += v*self.factors[i]
+        self.result[:] = 0
+        ##step 4
+        if index % 1 == 0:
+            index = int(index)
+        self.result[index] = 1
+        return self.result
+
+    def get_state(self, state, env=None):
+
+        discrete_state = state
+
+        state_space_low = env.observation_space.low
+        state_space_high = env.observation_space.high
+
+        discrete_obs_size = np.array(self.ranges)
+
+        discrete_obs_size = np.array(discrete_obs_size, dtype='int')
+        discrete_obs_win_size = (state_space_high - state_space_low) / discrete_obs_size
+
+        discrete_state = (state - state_space_low)/discrete_obs_win_size
+        discrete_state = tuple(discrete_state.astype(int))
+
+        return discrete_state

--- a/submissions/nengo-a2c/src/nengo_a2c/rules/__init__.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/rules/__init__.py
@@ -1,0 +1,4 @@
+from .td0 import TD0
+from .td_theta import TDt
+
+__all__ = ["TD0", "TDt"]

--- a/submissions/nengo-a2c/src/nengo_a2c/rules/td0.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/rules/td0.py
@@ -1,0 +1,128 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/rules/td0.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+No code edits from upstream.
+"""
+
+import nengo
+import numpy as np
+
+
+## TD(0) Learning Rule ##
+class TD0(nengo.processes.Process):
+    '''Create nengo Node with input, output and state.
+    This node is where the TD(0) learning rule is applied.
+
+    Inputs: state, reward, chosen action, whether or not the environment was reset
+    Outputs: updated state value, updated action values
+    '''
+    def __init__(self, n_actions, lr=0.1, act_dis=0.9, state_dis=0.95,
+                 n=None, lambd=None, env_dt=None, learnTrials=None):
+        self.n_actions = n_actions  ##number of possible actions for action-value space
+        self.lr = lr  ##learning rate
+        self.act_dis = act_dis  ##discount factor for action values
+        self.state_dis = state_dis  ##discount factor for state values
+        self.env_dt = env_dt  ##number of environment steps per simulation step
+        self.learnTrials = learnTrials  ##number of trials where agent learns
+
+        self.count = -1
+
+        if self.env_dt is not None:
+            self.lr = lr/(self.env_dt/0.001)
+
+        ## Input = reward + state representation + action values for current state
+        ## Output = action values for current state + state value
+        super().__init__(default_size_in=n_actions + 2, default_size_out=n_actions + 1)
+
+    def make_state(self, shape_in, shape_out, dt, dtype=None):
+        '''Get a dictionary of signals to represent the state of this process.
+        This will include: the representation of the state being updated (update_state_rep),
+        the initial value of the state (0) (update_value), and the weight matrix/look-up table (w).
+        Weight matrix shape = [(n_actions + state) * size of state representation output]'''
+
+        ## set dim = length of each row in matrix/look-up table
+        ## where a nengo ensemble is used to store the state representation,
+        ## this is equal to the number of neurons in the ensemble
+        dim = shape_in[0]-2-self.n_actions
+
+        ## return the state dictionary
+        return dict(update_state_rep=np.zeros(dim),
+                    update_value=0,
+                    w=np.zeros((self.n_actions+1, dim)))
+
+    def make_step(self, shape_in, shape_out, dt, rng, state):
+        '''Create function that advances the process forward one time step.'''
+        ## set dim = length of each row in matrix/look-up table
+        ## where a nengo ensemble is used to store the state representation,
+        ## this is equal to the number of neurons in the ensemble
+        dim = shape_in[0]-2-self.n_actions
+
+        ## One time step
+        def step_TD0(t, x, state=state):
+            ''' Function for performing TD(0) update at each timestep.
+            Inputs: state representation, chosen action, reward
+                and whether or not the env was reset
+            Params:
+                t = time
+                x = inputs
+                state = the dictionary created in make_state.
+            Outputs: updated state value, updated action values'''
+
+            current_state_rep = x[:dim]  ##get the state representation of current state
+            update_state_rep = state['update_state_rep']  ##get representation of state being updated
+            update_action = x[dim:-2]  ##get the action being updated (i.e. the action that was taken)
+            reward = x[-2]  ##get reward received following action
+            reset = x[-1]  ##get whether or not env was reset
+
+            ## get the dot product of the weight matrix and state representation
+            ## results in 1 value for the state, and 1 value for each action
+            result_values = state['w'].dot(current_state_rep)
+
+            ## get the value of the current state
+            current_state_value = result_values[0]
+
+            if reset:
+                ## Increase trial count for tracking learning trials
+                if self.env_dt is not None:
+                    self.count += 1/(self.env_dt/0.001)
+                else:
+                    self.count += 1
+
+
+            if self.learnTrials is None or self.count < self.learnTrials:
+                ## Do the TD(0) update
+                if not reset:  ##skip this if the env has just been reset
+                    ## calculate td error term
+                    td_error = reward + (self.state_dis*current_state_value) - state['update_value']
+
+                    ## calculate a scaling factor
+                    ## this scaling factor allows us to switch from updating
+                    ## a look-up table to updating weights
+                    scale = np.sum(update_state_rep**2)
+                    if scale != 0:
+                        scale = 1.0 / scale
+
+                    ## update the state value
+                    state['w'][0] += self.lr*td_error*update_state_rep*scale
+                    ## update the action values
+                    ## multiply the entire state represention by (action value * beta * tderror)
+                    ## scale these values and then update the weight matrix/look-up table
+                    dw = np.outer(update_action*self.act_dis*td_error, update_state_rep)
+
+
+                    state['w'][1:] += dw*scale
+
+            ## calculate the updated value for update state and add it to the result_values array
+            result_values[0] = state['w'].dot(state['update_state_rep'][:])[0]
+            ## change the state to be updated to the current state in this step
+            state['update_state_rep'][:] = current_state_rep
+            ## change the value being updated to the value of the current state in this step
+            state['update_value'] = current_state_value
+
+            ## return updated state value for update state and action values for current state
+            return result_values
+        return step_TD0

--- a/submissions/nengo-a2c/src/nengo_a2c/rules/td_theta.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/rules/td_theta.py
@@ -1,0 +1,155 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/rules/tdtheta.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+No code edits from upstream.
+"""
+
+import nengo
+import numpy as np
+
+
+## TD(theta) = TD(n) with LDN memories for rewards and state values ##
+## If operating in discrete time, is TD(n) with LDNs
+## If operating in continuous time, is TD(theta)
+class TDt(nengo.processes.Process):
+    '''Create nengo Node with input, output and state.
+    This node is where the TD(n) learning rule is applied.
+
+    Inputs: state, reward, chosen action, whether or not the environment was reset
+    Outputs: updated state value, updated action values
+    '''
+
+    def __init__(self, n_actions, lr=0.1, act_dis=0.85, state_dis=0.9,
+                 n=1, lambd=None, env_dt=None, learnTrials=None):
+        self.n_actions = n_actions  ##number of possible actions for action-value space
+        self.lr = lr  ##learning rate
+        self.act_dis = act_dis  ##discount factor for action values
+        self.state_dis = state_dis  ##discount factor for state values
+        self.n = n  ##value of n - the number of steps between the current state and the state being updated
+        self.env_dt = env_dt  ##number of environment steps per simulation step
+        self.learnTrials = learnTrials  ##number of trials where agent learns
+
+        self.step_count = 0
+        self.count = -1
+
+        if self.env_dt is not None:
+            self.lr = lr/(self.env_dt/0.001)
+
+        ## Input = reward + state representation + action values for current state
+        ## Output = action values for current state + state value
+        super().__init__(default_size_in=n_actions + 2, default_size_out=n_actions + 2)
+
+    def make_state(self, shape_in, shape_out, dt, dtype=None):
+        '''Get a dictionary of signals to represent the state of this process.
+        This will include: the representation of the state being updated (update_state_rep),
+        and the weight matrix/look-up table (w).
+        Weight matrix shape = [(n_actions + state) * size of state representation output]'''
+
+        ## set dim = length of each row in matrix/look-up table
+        ## where a nengo ensemble is used to store the state representation,
+        ## this is equal to the number of neurons in the ensemble
+        dim = shape_in[0]-3-self.n_actions
+
+        ## return the state dictionary
+        return dict(update_state_rep=np.zeros(dim),
+                    w=np.zeros((self.n_actions+1, dim)))
+
+    def make_step(self, shape_in, shape_out, dt, rng, state):
+        '''Create function that advances the process forward one time step.'''
+        ## set dim same as above
+        dim = shape_in[0]-3-self.n_actions
+
+        state_memory = []  ##list for storing the last n states
+        action_memory = []  ##list for storing the last n chosen actions
+
+        ## One time step
+        def step_TDtheta(t, x, state=state):
+            ''' Function for performing TD(n) update at each timestep.
+            Inputs: state representation, chosen action, reward
+                and whether or not the env was reset
+            Params:
+                t = time
+                x = inputs
+                state = the dictionary created in make_state.
+            Outputs: updated state value, updated action values'''
+            n = int(self.n)
+
+            current_state_rep = x[:dim]  ##get the state representation of current state
+            update_state_rep = state['update_state_rep']  ##get representation of the state being updated
+            last_action = x[dim:-3]  ##get the action that was taken
+            reward = x[-3]  ##get return
+            reset = x[-2]  ##get whether or not env was reset
+            update_state_value = x[-1]  ##get the current value of the state being updated
+
+
+            ## get the dot product of the weight matrix and state representation
+            ## results in 1 value for the state, and 1 value for each action
+            result_values = state['w'].dot(current_state_rep[:])
+
+            ## get the value of the current state
+            current_state_value = result_values[0]
+
+            ## Do the TD(n) update
+            ## if the environemt has just been reset, set the count to 0 and empty the memory lists
+            if reset:
+                self.step_count = 0
+                state_memory.clear()
+                action_memory.clear()
+
+                ## Increase trial count for tracking learning trials
+                if self.env_dt is not None:
+                    self.count += 1/(self.env_dt/0.001)
+                else:
+                    self.count += 1
+
+            if self.learnTrials is None or self.count < self.learnTrials:
+                if not reset:  ## skip this if the env has just been reset
+                    ## add the most recent reward and action to the memories
+                    action_memory.append(last_action)
+
+                    ## Start updating after n steps
+                    if self.step_count >= n:
+                        ## calculate td error term
+                        target = reward + ((self.state_dis**n)*current_state_value)
+                        td_error = target - update_state_value
+
+                        ##calculate a scaling factor
+                        ##this scaling factor allows us to switch from updating
+                        ##a look-up table to updating weights
+                        scale = np.sum(update_state_rep**2)
+                        if scale != 0:
+                            scale = 1.0 / scale
+
+                        ## update the state value
+                        state['w'][0] += self.lr*td_error*update_state_rep*scale
+
+                        ## update the action values
+                        ## multiply the entire state represention by (action value * act_dis * tderror)
+                        ## scale these values and then update the weight matrix/look-up table
+                        dw = np.outer(action_memory[0]*self.act_dis*td_error, update_state_rep)
+                        state['w'][1:] += dw*scale
+
+                        ## delete the first value in each memory list
+                        state_memory.pop(0)
+                        action_memory.pop(0)
+
+            ##increase count by 1
+            self.step_count += 1
+            ##add the most recent state and value to the memories
+            state_memory.append(current_state_rep.copy())
+
+            ##calculate the updated value for update state and add it to the result_values array
+            result_values[0] = state['w'].dot(state['update_state_rep'][:])[0]
+            ##change the state to be updated to the new first value in the state memory
+            state['update_state_rep'][:] = state_memory[0][:]
+
+            ##append the value of the current state (to be fed into State_Value LDN memory)
+            result_values = np.append(result_values, current_state_value)
+
+            ##return updated state value for update state and action values for current state
+            return result_values
+        return step_TDtheta

--- a/submissions/nengo-a2c/src/nengo_a2c/utils.py
+++ b/submissions/nengo-a2c/src/nengo_a2c/utils.py
@@ -1,0 +1,38 @@
+"""
+Vendored from https://github.com/maddybartlett/ImprovedRLContinuousStateReps
+(network/rlnet/utils.py), commit fc75ae0 (2024-02-01).
+
+This file is © Maddy Bartlett et al. and distributed under the Applied Brain
+Research academic-use-only license — see LICENSE at the submission root.
+
+Local edits relative to upstream:
+  - Only `sparsity_to_x_intercept` (used by the actor-critic networks) and
+    `softmax` (useful for action selection in examples) are vendored. The
+    upstream `rend`, `save_gifs`, `next_power_of_2`, `get_ac_output`,
+    `plot_policy`, and `plot_table` helpers are dropped — they depend on
+    matplotlib + matplotlib.animation and hardcode RatBox/CartPole grid
+    geometry, so they're not generally reusable.
+  - Removed the matplotlib import (no longer needed).
+"""
+
+import math  # noqa: F401  (kept to preserve upstream module-level imports)
+
+import numpy as np
+import scipy.special
+from scipy.special import log_softmax
+
+
+## Convert sparsity parameter to neuron bias/intercept
+def sparsity_to_x_intercept(d, p):
+    sign = 1
+    if p > 0.5:
+        p = 1.0 - p
+        sign = -1
+    return sign * np.sqrt(1 - scipy.special.betaincinv((d-1)/2.0, 0.5, 2*p))
+
+
+## Softmax Function used for selecting next action
+def softmax(x, axis=None):
+    """Compute softmax values for each sets of scores in x."""
+    filtered_x = np.nan_to_num(x-x.max())
+    return np.exp(log_softmax(filtered_x, axis=axis))

--- a/submissions/nengo-a2c/tests/test_runs.py
+++ b/submissions/nengo-a2c/tests/test_runs.py
@@ -1,0 +1,88 @@
+"""Tier-1 sanity tests for the nengo-a2c submission."""
+
+import numpy as np
+
+from nengo_a2c import (
+    ActorCritic,
+    ActorCriticLDN,
+    LDN,
+    NormalRep,
+    OneHotRepCP,
+    OneHotRepRB,
+    TD0,
+    TDt,
+    softmax,
+    sparsity_to_x_intercept,
+)
+
+
+def test_imports():
+    assert ActorCritic is not None
+    assert ActorCriticLDN is not None
+    assert LDN is not None
+    assert TD0 is not None
+    assert TDt is not None
+    assert NormalRep is not None
+    assert OneHotRepCP is not None
+    assert OneHotRepRB is not None
+    assert callable(softmax)
+    assert callable(sparsity_to_x_intercept)
+
+
+def test_actor_critic_builds_and_steps():
+    """Basic A2C builds, accepts a few steps, and emits correctly-shaped outputs."""
+    rep = OneHotRepCP(ranges=(3, 3))
+    rule = TD0(n_actions=2, lr=0.1, act_dis=0.9, state_dis=0.95)
+    ac = ActorCritic(rep, rule)
+
+    sv, av = ac.step((0, 0), 0, reward=0.0, reset=True)
+    assert sv.shape == (1,)
+    assert av.shape == (2,)
+
+    for _ in range(5):
+        sv, av = ac.step((0, 0), 0, reward=1.0, reset=False)
+    # After several positive-reward updates the weight row for the visited
+    # state must be non-zero (otherwise the rule never fired).
+    assert not np.allclose(av, 0), "action values still zero after reward updates"
+
+
+def test_actor_critic_with_state_ensemble_builds():
+    """A2C with a state ensemble in front of the rule node."""
+    rep = OneHotRepCP(ranges=(3, 3))
+    rule = TD0(n_actions=2, lr=0.1)
+    ac = ActorCritic(rep, rule, state_neurons=30, active_prop=0.2)
+    sv, av = ac.step((0, 0), 0, reward=0.0, reset=True)
+    sv, av = ac.step((0, 0), 0, reward=0.0)
+    assert sv.shape == (1,)
+    assert av.shape == (2,)
+
+
+def test_actor_critic_ldn_builds_and_steps():
+    """LDN variant builds with the TDt rule and emits correctly-shaped outputs."""
+    rep = OneHotRepCP(ranges=(3, 3))
+    rule = TDt(n_actions=2, lr=0.1, act_dis=0.85, state_dis=0.9, n=2, env_dt=0.001)
+    ac = ActorCriticLDN(
+        rep, rule,
+        state_neurons=30, active_prop=0.2,
+        theta=0.005, q_r=3, q_v=3,
+        continuous=False,
+    )
+    sv, av = ac.step((0, 0), 0, reward=0.0, reset=True)
+    sv, av = ac.step((0, 0), 0, reward=0.5)
+    assert sv.shape == (1,)
+    assert av.shape == (2,)
+
+
+def test_ldn_process_runs_standalone():
+    """The LDN nengo.Process builds and produces q*size_in-shaped output per step."""
+    import nengo
+    ldn = LDN(theta=0.05, q=4, size_in=1)
+    with nengo.Network() as net:
+        u = nengo.Node(lambda t: np.sin(2 * np.pi * 5 * t))
+        memory = nengo.Node(ldn, size_in=1)
+        nengo.Connection(u, memory, synapse=None)
+        probe = nengo.Probe(memory, synapse=None)
+    with nengo.Simulator(net) as sim:
+        sim.run(0.05)
+    # 50 ms / 1 ms timestep = 50 samples; q=4 dims.
+    assert sim.data[probe].shape == (50, 4)


### PR DESCRIPTION
## What

Adds a new `network`-type submission, [`nengo-a2c`](submissions/nengo-a2c), vendoring a focused cut of `rlnet/` from [Bartlett et al. (2022)](https://mathpsych.org/presentation/1221), *"Improving Reinforcement Learning with Biologically Motivated Continuous State Representations"* (ICCM).

Vendored upstream: <https://github.com/maddybartlett/ImprovedRLContinuousStateReps> @ commit `fc75ae0` (2024-02-01).

## Public API exposed

```python
from nengo_a2c import (
    ActorCritic,        # basic single-layer A2C
    ActorCriticLDN,     # A2C with LDN reward/value memories for multi-step TD
    LDN,                # nengo.Process — Legendre Delay Network
    TD0,                # one-step TD(0) rule
    TDt,                # n-step / continuous-time TD rule (a.k.a. TD-theta)
    NormalRep,
    OneHotRepCP, OneHotRepRB,
    softmax, sparsity_to_x_intercept,
)
```

The A2C classes are *trainer-style*: each constructs its own `nengo.Network`, instantiates its own `nengo.Simulator`, and exposes `step(state, action, reward, reset=False)`. They are **not** drop-in `nengo.Network` subclasses — the README flags this clearly.

## ⚠️ License

**This is the first non-GPL-compatible submission.** Upstream is distributed under Applied Brain Research's academic-use-only license — not SPDX-listed and not GPL-compatible. To stay faithful to upstream terms, this submission uses `LicenseRef-ABR-Academic-Use-Only` and reproduces the full ABR license text in `LICENSE`, along with a note explaining what's vendored and what is original to this submission.

Academic research, teaching, and personal learning are permitted without payment; commercial use requires a paid ABR license (sales@appliedbrainresearch.com). The README repeats this warning in a callout up top.

If maintainers prefer to refuse non-GPL-compatible submissions on principle, that's a fair call — happy to close.

## Scope decisions

**Vendored (focused, minimal):** `ActorCritic`, `ActorCriticLDN`, `LDN`, `TD0`, `TDt`, `NormalRep`, `OneHotRepCP`, `OneHotRepRB`, plus `sparsity_to_x_intercept` and `softmax` from `utils.py`.

**Deliberately not vendored:** `sspspace.py` (~800 LoC, warrants its own submission), `representations/{ssp,vsa,onehottransform}.py`, `rules/{td0iG,tdlambda,tdn}.py` (overlap with `TD0`/`TDt`), all cartpole/ratbox experiment scripts and figure generators, and the plotting/animation helpers in upstream `utils.py` (`plot_policy`, `get_ac_output`, `save_gifs`, etc.). The "What's not vendored" section of the README lists each upstream path explicitly for anyone wanting to expand later.

## Local edits to vendored files

Each vendored file carries a header noting:

- Source path in upstream + commit SHA + date
- ABR license attribution
- Local edits, if any

Concretely:
- `actor_critic.py`, `actor_critic_ldn.py`: dropped top-level `matplotlib.pyplot` import; dropped `get_tuning()` (plotting one-liner) and `get_policy()` (hardcoded for the RatBox 8×8×4 grid — not generally reusable); switched `from rlnet.utils import …` to relative `..utils`.
- `representations/onehot.py`: `OneHotRepRB.get_state` — `np.int` → `int`. (`np.int` was deprecated in NumPy 1.20 and removed in 1.24; bare `int` is the long-standing NumPy-recommended replacement.)
- `utils.py`: kept only `sparsity_to_x_intercept` and `softmax`; dropped matplotlib + animation imports.
- `td0.py`, `td_theta.py`, `ldn.py`, `representations/normal.py`: no code edits, header only.

## Files

- `LICENSE` — `LicenseRef-ABR-Academic-Use-Only` with full upstream license text + scope note
- `metadata.yaml`, `README.md`, `requirements.txt` (nengo + numpy + scipy — no matplotlib)
- `src/nengo_a2c/` — the vendored package
- `examples/example_usage.py` — self-contained 5×5 gridworld, ~80 episodes, runs in <1 s
- `tests/test_runs.py` — 5 tests (imports + both AC variants + LDN process standalone)

## Author

Single author listed: Maddy Bartlett. Other paper co-authors are credited in the README's citation block. Maddy's ORCID to be added once known (I'll defer to a maintainer).

## Checklist

- [x] `python tools/validate_submission.py submissions/nengo-a2c` → PASS
- [x] `pytest tests/` → 5 passed under Nengo 4.1.0
- [x] `python examples/example_usage.py` → trains from -0.03 → +0.93 avg episode reward in 0.75 s
- [x] No matplotlib dependency (vendored utils dropped the plotting helpers)
- [x] Schema-accepted non-SPDX `LicenseRef-…` string with full original license text in `LICENSE`
