### PR TITLE
sync_zenodo: zenodo_license override (fixes nengo-a2c deposit)

### DIFF
--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -52,6 +52,11 @@
       "description": "SPDX license identifier. Default: GPL-2.0-or-later (matches Nengo).",
       "examples": ["GPL-2.0-or-later", "GPL-3.0-or-later", "MIT", "BSD-3-Clause"]
     },
+    "zenodo_license": {
+      "type": "string",
+      "description": "Override for the Zenodo deposition license. Zenodo's legacy deposit API only accepts ids from its controlled vocabulary (see https://zenodo.org/api/licenses), so submissions whose real SPDX `license` is a `LicenseRef-...` custom identifier need to map onto something Zenodo recognises. Closest catch-alls: 'other-open' (open, not in vocab), 'other-nc' (non-commercial), 'other-closed' (proprietary), 'other-pd' (public-domain), 'other-at' (attribution).",
+      "examples": ["other-nc", "other-closed", "other-open"]
+    },
     "description": {
       "type": "string",
       "minLength": 30,

--- a/submissions/nengo-a2c/metadata.yaml
+++ b/submissions/nengo-a2c/metadata.yaml
@@ -1,12 +1,16 @@
 name: nengo-a2c
 type: network
-version: 0.2.0
+version: 0.2.1
 
 authors:
   - name: Maddy Bartlett
     orcid: 0000-0003-1084-0938
 
 license: LicenseRef-ABR-Academic-Use-Only
+# Zenodo's legacy deposit API rejects `LicenseRef-...` SPDX custom ids;
+# `other-nc` (Non-Commercial) is the closest match in Zenodo's controlled
+# vocabulary for ABR Academic Use Only.
+zenodo_license: other-nc
 
 description: >
   A spiking Actor-Critic reinforcement learning network from Bartlett et al.

--- a/tools/sync_zenodo.py
+++ b/tools/sync_zenodo.py
@@ -134,9 +134,17 @@ def zenodo_metadata(meta: dict) -> dict:
         "keywords": meta.get("tags", []) or [],
         "access_right": "open",
     }
-    # Zenodo (InvenioRDM) expects SPDX license ids in lower case. Best-effort:
-    # if the id is wrong the metadata PUT will fail loudly and we adjust.
-    if meta.get("license"):
+    # Zenodo (InvenioRDM) expects an id from its controlled licenses vocabulary
+    # (https://zenodo.org/api/licenses) — lowercased SPDX ids work for most of
+    # the common ones, but `LicenseRef-...` SPDX custom identifiers are not
+    # accepted. Submissions whose real license needs a non-SPDX deposit id can
+    # set `zenodo_license:` in metadata.yaml to override (e.g. `other-nc` for
+    # academic-use-only / non-commercial licenses); otherwise we fall back to
+    # the plain `license:` field, which we just lowercase.
+    license_override = meta.get("zenodo_license")
+    if license_override:
+        md["license"] = str(license_override).lower()
+    elif meta.get("license"):
         md["license"] = str(meta["license"]).lower()
     return md
 


### PR DESCRIPTION
## Summary

The Zenodo deposit step on the `pages.yml` (or `zenodo.yml`) workflow failed for `nengo-a2c` with:

```
FAIL: nengo-a2c: PUT https://zenodo.org/api/deposit/depositions/20648699 ->
HTTP 400: {"errors":[{"field":"metadata.license",
"messages":["Invalid license provided: licenseref-abr-academic-use-only"]}]}
```

`nengo-a2c`'s real SPDX license is `LicenseRef-ABR-Academic-Use-Only` — a SPDX *custom* identifier. Zenodo's legacy deposit API only accepts ids from its controlled vocabulary at https://zenodo.org/api/licenses (lowercased SPDX ids like `gpl-2.0-or-later` work; arbitrary `licenseref-...` strings don't).

Adds an optional `zenodo_license` metadata field that overrides the deposition's license id without touching the submission's real SPDX `license:` declaration. The Zoo site page and zip continue to show ABR Academic Use Only — only the Zenodo record's category-tag changes.

Closest catch-all in Zenodo's vocabulary for ABR Academic Use Only (academic-free, commercial-restricted) is **`other-nc`** (Non-Commercial), which this PR sets on `nengo-a2c`.

Changes:

- `schema/metadata.schema.json` — add the optional `zenodo_license` property.
- `tools/sync_zenodo.py` — prefer `zenodo_license` over `license` when building the deposition payload.
- `submissions/nengo-a2c/metadata.yaml` — add `zenodo_license: other-nc`, bump version `0.2.0` → `0.2.1` so the bot retries the deposit.

## Test plan

- [x] `python tools/validate_submission.py submissions/nengo-a2c` → PASS (new field validates)
- [x] Re-running `sync_zenodo.py` against the sandbox (with a token) should now mint a v0.2.1 DOI for `nengo-a2c` cleanly — please verify on next workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
