### PR TITLE
CI: retry-with-rebase on bot push to main

### DIFF
--- a/.github/workflows/auto-discussion.yml
+++ b/.github/workflows/auto-discussion.yml
@@ -63,5 +63,20 @@ jobs:
             echo "No new discussion numbers to commit."
           else
             git commit -m "CI: link submissions to their discussion threads"
-            git push
+            # Retry-with-rebase against concurrent bot pushes on main.
+            # See review.yml's tested-on push step for the rationale.
+            for attempt in 1 2 3 4 5; do
+              if git push; then exit 0; fi
+              if [ "$attempt" = "5" ]; then
+                echo "Push failed after 5 attempts."
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempt/5) — rebasing on origin/main and retrying..."
+              if ! git pull --rebase origin main; then
+                echo "Rebase failed (likely a real conflict); cannot recover."
+                git rebase --abort 2>/dev/null || true
+                exit 1
+              fi
+              sleep $((RANDOM % 3 + 1))
+            done
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -289,5 +289,23 @@ jobs:
             echo "no changes to commit"
           else
             git commit -m "CI: refresh tested-on.json"
-            git push
+            # Retry-with-rebase: zenodo.yml, auto-discussion.yml, and this
+            # workflow all push to main with the bot's GITHUB_TOKEN; when two
+            # of them finish back-to-back the second push gets rejected as
+            # non-fast-forward. Pull --rebase between attempts so the loser
+            # picks up the winner's commit and tries again.
+            for attempt in 1 2 3 4 5; do
+              if git push; then exit 0; fi
+              if [ "$attempt" = "5" ]; then
+                echo "Push failed after 5 attempts."
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempt/5) — rebasing on origin/main and retrying..."
+              if ! git pull --rebase origin main; then
+                echo "Rebase failed (likely a real conflict); cannot recover."
+                git rebase --abort 2>/dev/null || true
+                exit 1
+              fi
+              sleep $((RANDOM % 3 + 1))
+            done
           fi

--- a/.github/workflows/zenodo.yml
+++ b/.github/workflows/zenodo.yml
@@ -68,5 +68,20 @@ jobs:
             echo "No new DOIs to commit."
           else
             git commit -m "CI: record Zenodo DOIs for released versions"
-            git push
+            # Retry-with-rebase against concurrent bot pushes on main.
+            # See review.yml's tested-on push step for the rationale.
+            for attempt in 1 2 3 4 5; do
+              if git push; then exit 0; fi
+              if [ "$attempt" = "5" ]; then
+                echo "Push failed after 5 attempts."
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempt/5) — rebasing on origin/main and retrying..."
+              if ! git pull --rebase origin main; then
+                echo "Rebase failed (likely a real conflict); cannot recover."
+                git rebase --abort 2>/dev/null || true
+                exit 1
+              fi
+              sleep $((RANDOM % 3 + 1))
+            done
           fi


### PR DESCRIPTION
## Summary

Fixes the multi-bot race condition where two of review.yml, zenodo.yml, or auto-discussion.yml finish back-to-back and the second one's push to main is rejected as non-fast-forward.

All three workflows previously did a plain \`git push\` after committing — see e.g. review.yml's \`aggregate-tested-on\` step. This wraps each push in a 5-attempt retry loop that pulls --rebase between attempts (with jitter) and exits cleanly if a real (non-fast-forward) merge conflict shows up.

The vulnerable pattern was identical across all three workflows, so the fix is identical too.

## Test plan

- [x] No behavioral change to the happy path (single-bot push still succeeds in one attempt)
- [x] The bash retry loop is self-contained inside the existing \`run:\` block; no new permissions or steps required
- [ ] On the next two-bot-near-collision in main, the losing bot should now succeed after one rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)